### PR TITLE
Added file icon colours

### DIFF
--- a/src/main/resources/rose_pine_dawn.theme.json
+++ b/src/main/resources/rose_pine_dawn.theme.json
@@ -26,6 +26,17 @@
     "highlightInactive": "#f2ede9",
     "highlightOverlay": "#e4dfde"
   },
+  "icons": {
+    "ColorPallete": {
+      "Actions.Grey": "#26233a",
+      "Actions.Blue": "#31748f",
+      "Actions.Green": "#9ccfd8",
+      "Actions.Red": "#eb6f92",
+      "Actions.Yellow": "#f6c177",
+      "Actions.GreyInline": "#908caa",
+      "Actions.GreyInlineDark": "#6e6a86"
+    }
+  },
   "ui": {
     "*": {
       "background": "base",


### PR DESCRIPTION
This pull request attempts to fix the issue #15. Let me know if the icons are looking good. 

The colours are taken from the [official Rose Pine palette](https://rosepinetheme.com/palette)

I have not tested it in my computer, but I have written the code according to the Catppuccin theme code over [here](https://github.com/catppuccin/jetbrains/blob/main/generateFlavours/types.ts).

For now, I have added it only for the Rose Pine Dawn version. If it is good, I will open a separate pull request containing the Rose Pine Dark patch.