### PR TITLE
Dawn theme highlighted text and console colour backgrounds

### DIFF
--- a/src/main/resources/rose_pine_dawn.theme.json
+++ b/src/main/resources/rose_pine_dawn.theme.json
@@ -22,7 +22,7 @@
     "pine1a": "#2869835a",
     "foam1a": "#56949f5a",
     "iris1a": "#907aa95a",
-    "highlight": "#eee9e6",
+    "highlight": "#dfdad9",
     "highlightInactive": "#f2ede9",
     "highlightOverlay": "#e4dfde"
   },

--- a/src/main/resources/rose_pine_dawn.xml
+++ b/src/main/resources/rose_pine_dawn.xml
@@ -252,12 +252,12 @@
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="FF" />
+        <option name="FOREGROUND" value="286983" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="B2B2" />
+        <option name="FOREGROUND" value="D7827E" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -267,27 +267,27 @@
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="595959" />
+        <option name="FOREGROUND" value="9893A5" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="8000" />
+        <option name="FOREGROUND" value="56949F" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="FF00FF" />
+        <option name="FOREGROUND" value="907AA9" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="000000" />
+        <option name="FOREGROUND" value="575279" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="FF0000" />
+        <option name="FOREGROUND" value="B4637A" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
@@ -303,7 +303,7 @@
     </option>
     <option name="CONSOLE_YELLOW_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="FFCC00" />
+        <option name="FOREGROUND" value="EA9D34" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -977,7 +977,7 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="CCCCCC" />
+        <option name="EFFECT_COLOR" value="3592C4" />
         <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
       </value>
     </option>

--- a/src/main/resources/rose_pine_dawn.xml
+++ b/src/main/resources/rose_pine_dawn.xml
@@ -2,7 +2,7 @@
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="FAF4ED" />
     <option name="LINE_NUMBERS_COLOR" value="575279" />
-    <option name="SELECTION_BACKGROUND" value="EFE9E4" />
+    <option name="SELECTION_BACKGROUND" value="DFDAD9" />
     <option name="CARET_ROW_COLOR" value="F2ECE7" />
     <option name="WHITESPACES" value="9893A5" />
     <option name="CARET_COLOR" value="9893A5" />


### PR DESCRIPTION
Following from #18, applies similar changes to console text colours for dawn theme using [rosé pine dawn palette](https://rosepinetheme.com/palette/ingredients/#rose-pine-dawn).

closes #9 