### PR TITLE
Fix(Dawn): use a clearer fg color for secondary button

### DIFF
--- a/src/main/resources/rose_pine_dawn.theme.json
+++ b/src/main/resources/rose_pine_dawn.theme.json
@@ -76,7 +76,7 @@
       "endBackground": "subtle",
       "startBorderColor": "subtle",
       "endBorderColor": "subtle",
-      "foreground": "text",
+      "foreground": "base",
       "default": {
         "foreground": "base",
         "startBackground": "rose",


### PR DESCRIPTION
This PR change the fg text color in the button with a grey background to ensure that the text is readable.

Screenshot 📸 :

<img width="417" alt="Capture d’écran 2023-10-28 à 00 13 21" src="https://github.com/Jmorjsm/rose-pine-intellij/assets/17273325/04a9218f-1d33-4dec-a301-0be3af87d27a">

I am looking for the colors related to the help button but found nothing yet.

Closes #10 #21 