### PR TITLE
Updates for IntelliJ Platform 233.*, rename themes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@
 pluginGroup = com.github.jmorjsm.rosepineintellij
 pluginName = rose-pine-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.8
+pluginVersion = 0.0.9
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 213
-pluginUntilBuild = 232.*
+pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC

--- a/src/main/resources/rose_pine.theme.json
+++ b/src/main/resources/rose_pine.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "rose-pine",
+  "name": "Rosé Pine",
   "dark": true,
   "author": "jmorjsm",
   "editorScheme": "/rose_pine.xml",

--- a/src/main/resources/rose_pine.xml
+++ b/src/main/resources/rose_pine.xml
@@ -1,4 +1,4 @@
-<scheme name="Rose-pine-color-theme" parent_scheme="Darcula" version="1">
+<scheme name="Rosé Pine" parent_scheme="Darcula" version="1">
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="191724" />
     <option name="LINE_NUMBERS_COLOR" value="E0DEF4" />

--- a/src/main/resources/rose_pine_dawn.theme.json
+++ b/src/main/resources/rose_pine_dawn.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "rose-pine-dawn",
+  "name": "Rosé Pine Dawn",
   "dark": false,
   "author": "",
   "editorScheme": "/rose_pine_dawn.xml",

--- a/src/main/resources/rose_pine_dawn.xml
+++ b/src/main/resources/rose_pine_dawn.xml
@@ -1,4 +1,4 @@
-<scheme name="Rose-pine-dawn-color-theme" parent_scheme="Default" version="1">
+<scheme name="Rosé Pine Dawn" parent_scheme="Default" version="1">
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="FAF4ED" />
     <option name="LINE_NUMBERS_COLOR" value="575279" />

--- a/src/main/resources/rose_pine_moon.theme.json
+++ b/src/main/resources/rose_pine_moon.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "rose-pine-moon",
+  "name": "Rosé Pine Moon",
   "dark": true,
   "author": "",
   "editorScheme": "/rose_pine_moon.xml",

--- a/src/main/resources/rose_pine_moon.xml
+++ b/src/main/resources/rose_pine_moon.xml
@@ -1,4 +1,4 @@
-<scheme name="Rose-pine-moon-color-theme" parent_scheme="Darcula" version="1">
+<scheme name="Rosé Pine Moon" parent_scheme="Darcula" version="1">
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="232136" />
     <option name="LINE_NUMBERS_COLOR" value="E0DEF4" />


### PR DESCRIPTION
Themes and Editor Color Schemes are now properly named "Rosé Pine", "Rosé Pine Dawn", and "Rosé Pine Moon".