### PR TITLE
Revert "Added file icon colours"

### DIFF
--- a/src/main/resources/rose_pine_dawn.theme.json
+++ b/src/main/resources/rose_pine_dawn.theme.json
@@ -26,17 +26,6 @@
     "highlightInactive": "#f2ede9",
     "highlightOverlay": "#e4dfde"
   },
-  "icons": {
-    "ColorPallete": {
-      "Actions.Grey": "#26233a",
-      "Actions.Blue": "#31748f",
-      "Actions.Green": "#9ccfd8",
-      "Actions.Red": "#eb6f92",
-      "Actions.Yellow": "#f6c177",
-      "Actions.GreyInline": "#908caa",
-      "Actions.GreyInlineDark": "#6e6a86"
-    }
-  },
   "ui": {
     "*": {
       "background": "base",


### PR DESCRIPTION
@DereckExists, Upon testing these changes, I see that the dawn theme breaks, resulting in default light theme styling around the window. I don't think this fixes the icons as you wish either. We'll need to give this one another go. Reverting for now.

Expected:
![image](https://github.com/Jmorjsm/rose-pine-intellij/assets/6062228/81a695d3-989f-43e0-b779-1e42f466d82c)

Actual:
![image](https://github.com/Jmorjsm/rose-pine-intellij/assets/6062228/8195ad76-2331-4da3-9bf6-12094e8fb310)

Reverts Jmorjsm/rose-pine-intellij#16