### PR TITLE
Add Rosé Pine highlighting for some elements that didn't have Rosé Pine colours, especially Rust language support

### DIFF
--- a/src/main/resources/rose_pine.xml
+++ b/src/main/resources/rose_pine.xml
@@ -2058,6 +2058,25 @@
         <option name="FOREGROUND" value="F6C177" />
       </value>
     </option>
+    <option name="org.rust.ASSOC_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="org.rust.ASSOC_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FONT_TYPE" value="2" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="org.rust.ASSOC_TRAIT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="org.rust.CFG_DISABLED_CODE">
       <value>
         <option name="FOREGROUND" value="6e6a86" />
@@ -2085,76 +2104,9 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="org.rust.LIFETIME">
+    <option name="org.rust.FUNCTION">
       <value>
         <option name="FOREGROUND" value="9ccfd8" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="org.rust.MACRO">
-      <value>
-        <option name="FOREGROUND" value="9ccfd8" />
-      </value>
-    </option>
-    <option name="org.rust.MUT_SELF_PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="c4a7e7" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="org.rust.Q_OPERATOR">
-      <value>
-        <option name="FOREGROUND" value="eb6f92" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="org.rust.SELF_EXPRESSION">
-      <value>
-        <option name="FOREGROUND" value="c4a7e7" />
-      </value>
-    </option>
-    <option name="org.rust.SELF_PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="c4a7e7" />
-      </value>
-    </option>
-    <option name="org.rust.STATIC">
-      <value>
-        <option name="FOREGROUND" value="eb6f92" />
-      </value>
-    </option>
-    <option name="org.rust.STRING">
-      <value>
-        <option name="FOREGROUND" value="f6c177" />
-      </value>
-    </option>
-    <option name="org.rust.STRUCT">
-      <value>
-        <option name="FOREGROUND" value="ebbcba" />
-      </value>
-    </option>
-    <option name="org.rust.TRAIT" baseAttributes="DEFAULT_INTERFACE_NAME" />
-    <option name="org.rust.TYPE_ALIAS">
-      <value>
-        <option name="FOREGROUND" value="ebbcba" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="org.rust.TYPE_PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="ebbcba" />
-      </value>
-    </option>
-    <option name="org.rust.UNION">
-      <value>
-        <option name="FOREGROUND" value="ebbcba" />
-      </value>
-    </option>
-    <option name="org.rust.UNSAFE_CODE">
-      <value>
-        <option name="FOREGROUND" value="191724" />
-        <option name="BACKGROUND" value="eb6f92" />
-      </value>
-    </option>
   </attributes>
 </scheme>

--- a/src/main/resources/rose_pine.xml
+++ b/src/main/resources/rose_pine.xml
@@ -2092,6 +2092,11 @@
         <option name="FOREGROUND" value="EB6F92" />
       </value>
     </option>
+    <option name="org.rust.CRATE">
+        <value>
+            <option name="FOREGROUND" value="c4a7e7" />
+        </value>
+    </option>
     <option name="org.rust.ENUM">
       <value>
         <option name="FOREGROUND" value="EBBCBA" />

--- a/src/main/resources/rose_pine.xml
+++ b/src/main/resources/rose_pine.xml
@@ -16,6 +16,11 @@
         <option name="FOREGROUND" value="EB6F92" />
       </value>
     </option>
+    <option name="BASH.EXTERNAL_COMMAND">
+        <value>
+            <option name="FOREGROUND" value="31748F" />
+        </value>
+    </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="743D3D" />
@@ -324,6 +329,12 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
+    <option name="CSS.IMPORTANT">
+        <value>
+            <option name="FOREGROUND" value="EB6F92" />
+            <option name="FONT_TYPE" value="1" />
+        </value>
+    </option>
     <option name="CSS.NUMBER">
       <value>
         <option name="FOREGROUND" value="EBBCBA" />
@@ -362,13 +373,13 @@
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="FDA5FF" />
+        <option name="FOREGROUND" value="EBBCBA" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="71D7D7" />
+        <option name="FOREGROUND" value="9CCFD8" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -938,6 +949,11 @@
         <option name="FOREGROUND" value="555169" />
         <option name="FONT_TYPE" value="2" />
       </value>
+    </option>
+    <option name="HTML_CUSTOM_TAG_NAME">
+        <value>
+            <option name="FOREGROUND" value="9CCFD8" />
+        </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
@@ -2040,6 +2056,104 @@
     <option name="YAML_TEXT">
       <value>
         <option name="FOREGROUND" value="F6C177" />
+      </value>
+    </option>
+    <option name="org.rust.CFG_DISABLED_CODE">
+      <value>
+        <option name="FOREGROUND" value="6e6a86" />
+      </value>
+    </option>
+    <option name="org.rust.CHAR">
+      <value>
+        <option name="FOREGROUND" value="f6c177" />
+      </value>
+    </option>
+    <option name="org.rust.CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="eb6f92" />
+      </value>
+    </option>
+    <option name="org.rust.ENUM">
+      <value>
+        <option name="FOREGROUND" value="ebbcba" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="org.rust.ENUM_VARIANT">
+      <value>
+        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="org.rust.LIFETIME">
+      <value>
+        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="org.rust.MACRO">
+      <value>
+        <option name="FOREGROUND" value="9ccfd8" />
+      </value>
+    </option>
+    <option name="org.rust.MUT_SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="c4a7e7" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="org.rust.Q_OPERATOR">
+      <value>
+        <option name="FOREGROUND" value="eb6f92" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="org.rust.SELF_EXPRESSION">
+      <value>
+        <option name="FOREGROUND" value="c4a7e7" />
+      </value>
+    </option>
+    <option name="org.rust.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="c4a7e7" />
+      </value>
+    </option>
+    <option name="org.rust.STATIC">
+      <value>
+        <option name="FOREGROUND" value="eb6f92" />
+      </value>
+    </option>
+    <option name="org.rust.STRING">
+      <value>
+        <option name="FOREGROUND" value="f6c177" />
+      </value>
+    </option>
+    <option name="org.rust.STRUCT">
+      <value>
+        <option name="FOREGROUND" value="ebbcba" />
+      </value>
+    </option>
+    <option name="org.rust.TRAIT" baseAttributes="DEFAULT_INTERFACE_NAME" />
+    <option name="org.rust.TYPE_ALIAS">
+      <value>
+        <option name="FOREGROUND" value="ebbcba" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="org.rust.TYPE_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="ebbcba" />
+      </value>
+    </option>
+    <option name="org.rust.UNION">
+      <value>
+        <option name="FOREGROUND" value="ebbcba" />
+      </value>
+    </option>
+    <option name="org.rust.UNSAFE_CODE">
+      <value>
+        <option name="FOREGROUND" value="191724" />
+        <option name="BACKGROUND" value="eb6f92" />
       </value>
     </option>
   </attributes>

--- a/src/main/resources/rose_pine.xml
+++ b/src/main/resources/rose_pine.xml
@@ -262,7 +262,7 @@
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ebbcba" />
+        <option name="FOREGROUND" value="EBBCBA" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
@@ -272,12 +272,12 @@
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="6e6a86" />
+        <option name="FOREGROUND" value="6E6A86" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FOREGROUND" value="9CCFD8" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
@@ -292,7 +292,7 @@
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="eb6f92" />
+        <option name="FOREGROUND" value="EB6F92g" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
@@ -308,7 +308,7 @@
     </option>
     <option name="CONSOLE_YELLOW_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="f6c177" />
+        <option name="FOREGROUND" value="F6C177" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -2060,53 +2060,53 @@
     </option>
     <option name="org.rust.ASSOC_FUNCTION">
       <value>
-        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FOREGROUND" value="9CCFD8" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="org.rust.ASSOC_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FOREGROUND" value="9CCFD8" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="org.rust.ASSOC_TRAIT_FUNCTION_CALL">
       <value>
-        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FOREGROUND" value="9CCFD8" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="org.rust.CFG_DISABLED_CODE">
       <value>
-        <option name="FOREGROUND" value="6e6a86" />
+        <option name="FOREGROUND" value="6E6A86" />
       </value>
     </option>
     <option name="org.rust.CHAR">
       <value>
-        <option name="FOREGROUND" value="f6c177" />
+        <option name="FOREGROUND" value="F6C177" />
       </value>
     </option>
     <option name="org.rust.CONSTANT">
       <value>
-        <option name="FOREGROUND" value="eb6f92" />
+        <option name="FOREGROUND" value="EB6F92" />
       </value>
     </option>
     <option name="org.rust.ENUM">
       <value>
-        <option name="FOREGROUND" value="ebbcba" />
+        <option name="FOREGROUND" value="EBBCBA" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="org.rust.ENUM_VARIANT">
       <value>
-        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FOREGROUND" value="9CCFD8" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="org.rust.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="9ccfd8" />
+        <option name="FOREGROUND" value="9CCFD8" />
         <option name="FONT_TYPE" value="2" />
   </attributes>
 </scheme>


### PR DESCRIPTION
This PR is mostly for Rust language support, as previously using the Rosé Pine theme to view Rust code had a lot of common elements of Rust not in Rosé Pine colours. Here's what Rust code looks like with the PR:

<img width="921" height="401" alt="20250807_20h27m30s_grim" src="https://github.com/user-attachments/assets/411476e8-fb10-49dd-83b3-b17b9ed3aedb" />

I've also filled in a small number of other elements that didn't have Rosé Pine colours, but you can remove those changes if you only want to merge the Rust changes.